### PR TITLE
Client sim teleport fix

### DIFF
--- a/Packages/com.nessie.udon.movement/Runtime/Scripts/NUMovement.cs
+++ b/Packages/com.nessie.udon.movement/Runtime/Scripts/NUMovement.cs
@@ -541,6 +541,7 @@ namespace Nessie.Udon.Movement
         [PublicAPI]
         public virtual void _TeleportTo(Vector3 position, Quaternion rotation, bool lerpOnRemote = false)
         {
+#if !UNITY_EDITOR
             rotation = Quaternion.Euler(0, rotation.eulerAngles.y, 0);
             
             Vector3 playerPos = LocalPlayer.GetPosition();
@@ -558,6 +559,9 @@ namespace Nessie.Udon.Movement
             Vector3 targetPos = position + invPlayerRot * rotation * posOffset;
             
             _TeleportTo(targetPos, targetRot, VRC_SceneDescriptor.SpawnOrientation.AlignRoomWithSpawnPoint, lerpOnRemote);
+#else //Avoiding problem where ClientSim behaves differently to VRChat
+			_TeleportTo(position, rotation, orientation: VRC_SceneDescriptor.SpawnOrientation.Default, lerpOnRemote);
+#endif
         }
         
         [PublicAPI]

--- a/Packages/com.nessie.udon.movement/Runtime/Scripts/NUMovement.cs
+++ b/Packages/com.nessie.udon.movement/Runtime/Scripts/NUMovement.cs
@@ -560,7 +560,7 @@ namespace Nessie.Udon.Movement
             
             _TeleportTo(targetPos, targetRot, VRC_SceneDescriptor.SpawnOrientation.AlignRoomWithSpawnPoint, lerpOnRemote);
 #else //Avoiding problem where ClientSim behaves differently to VRChat
-			_TeleportTo(position, rotation, orientation: VRC_SceneDescriptor.SpawnOrientation.Default, lerpOnRemote);
+            _TeleportTo(position, rotation, orientation: VRC_SceneDescriptor.SpawnOrientation.Default, lerpOnRemote);
 #endif
         }
         


### PR DESCRIPTION
Fixed client sim teleport by using a preprocessor directives to bypass part of the unnecessary VRChat player origin recalculation.